### PR TITLE
Update premier-tour-sans-jadot.csv

### DIFF
--- a/presidentielle/2017/premier-tour-sans-jadot.csv
+++ b/presidentielle/2017/premier-tour-sans-jadot.csv
@@ -13,3 +13,4 @@ Ifop-Fiducial,"Ifop – Fiducial pour iTELE, Paris Match et Sud Radio",2017-03-0
 Harris Interactive,Harris Interactive pour France Télévisions l’Emission Politique,2017-03-06,2017-03-08,4533,0,1,0,12,13,26,20,3,25
 BVA,BVA,2017-03-08,2017-03-10,1419,0,0.5,0.5,11.5,13.5,26,20,2,26
 Ifop-Fiducial,"Ifop – Fiducial pour iTELE, Paris Match et Sud Radio",2017-03-12,2017-03-15,1399,0,0.5,0.5,11.5,13.5,25.5,18.5,3.5,26.5
+BVA, Enquête BVA-Salesforce pour la Presse Régionale et Orange,2017-03-15,2017-03-17,1425,0,1,0,12,12.5,25,19.5,3,26

--- a/presidentielle/2017/premier-tour-sans-jadot.csv
+++ b/presidentielle/2017/premier-tour-sans-jadot.csv
@@ -13,4 +13,4 @@ Ifop-Fiducial,"Ifop – Fiducial pour iTELE, Paris Match et Sud Radio",2017-03-0
 Harris Interactive,Harris Interactive pour France Télévisions l’Emission Politique,2017-03-06,2017-03-08,4533,0,1,0,12,13,26,20,3,25
 BVA,BVA,2017-03-08,2017-03-10,1419,0,0.5,0.5,11.5,13.5,26,20,2,26
 Ifop-Fiducial,"Ifop – Fiducial pour iTELE, Paris Match et Sud Radio",2017-03-12,2017-03-15,1399,0,0.5,0.5,11.5,13.5,25.5,18.5,3.5,26.5
-BVA, Enquête BVA-Salesforce pour la Presse Régionale et Orange,2017-03-15,2017-03-17,1425,0,1,0,12,12.5,25,19.5,3,26
+BVA, Enquête BVA-Salesforce pour la Presse Régionale et Orange,2017-03-15,2017-03-17,935,0,1,0,12,12.5,25,19.5,3,26


### PR DESCRIPTION
sondage pour pop2017.fr, levée d'embargo 18 mars 4:00am.
Les intentions de vote qui figurent dans ce rapport reposent sur la base des personnes inscrites sur les listes électorales, certaines d’aller voter et ayant exprimé une intention de vote, soit 935 individus. Pour cet effectif, pour un pourcentage obtenu par enquête de 20%, la marge d’erreur est égale à 2,6.
http://www.bva.fr/data/sondage/sondage_fiche/1962/fichier_intentions_de_vote_-_vague_13_-_pop2017_-_18_mars_2017_-_presentationd5dd0.pdf

Note: la somme ne fait pas 100% car Asselineau est crédité de 1% (non présent dans votre étude). Cheminade n'est pas sondé.