### PR TITLE
Suppression du dernier Ifop

### DIFF
--- a/presidentielle/2017/premier-tour-officiel.csv
+++ b/presidentielle/2017/premier-tour-officiel.csv
@@ -39,4 +39,3 @@ Ifop-Fiducial,"Ifop – Fiducial pour CNEWS, Paris Match et Sud Radio",2017-04-1
 BVA,BVA,2017-04-12,2017-04-14,1439,1,1.5,20,7.5,23,1,20,3,1,22,0
 OpinionWay,Sondage OpinionWay/ORPI pour Les Echos & Radio Classique,2017-04-14,2017-04-16,2168,1,2,18,8,22,2,21,3,1,22,0
 Elabe,ELABE pour BFMTV et L’EXPRESS,2017-04-16,2017-04-17,1438,0.5,2,18,8,24,0.5,19.5,4,0.5,23,0
-Ifop-Fiducial,"Ifop – Fiducial pour CNEWS, Paris Match et Sud Radio",2017-04-14,2017-04-17,0.5,1.5,19.5,7.5,23,1,19.5,4,1,22.5,0


### PR DESCRIPTION
- j'avais oublié d'indiquer le nombre de sondés (entre 1000 et 2000 de mémoire),
- il n'apparaît plus sur Wikipédia (pour une raison inconnue... c'était peut-être un doublon partiel du sondage Ifop précédent)
⇒  J'ai donc décidé de le retirer du fichier.